### PR TITLE
サポート外のため、IISでの設定例を削除

### DIFF
--- a/pages/quickstart/install.md
+++ b/pages/quickstart/install.md
@@ -193,34 +193,6 @@ SetEnv ECCUBE_COOKIE_PATH /
 
 [参考: Apache HTTP サーバ バージョン 2.4 - SetEnv ディレクティブ](https://httpd.apache.org/docs/2.4/ja/mod/mod_env.html#setenv)
 
-### IIS での設定例
-
-ApplicationHost.config の environmentVariables セクションに設定します。このファイルは `C:\Windows\System32\Inetsrv\Config` にあります。
-PHP実行ファイルのパスは適宜変更してください。
-
-```xml
-<fastCgi>
-    <application fullPath="C:\Program Files\PHP\v7.2\php-cgi.exe" activityTimeout="600" requestTimeout="600" instanceMaxRequests="10000">
-        <environmentVariables>
-            <environmentVariable name="PHP_FCGI_MAX_REQUESTS" value="10000" />
-            <environmentVariable name="PHPRC" value="C:\Program Files\PHP\v7.2" />
-            <environmentVariable name="APP_ENV" value="prod" />
-            <environmentVariable name="APP_DEBUG" value="0" />
-            <environmentVariable name="DATABASE_URL" value="pgsql://dbuser:password@127.0.0.1/cube4_dev" />
-            <environmentVariable name="DATABASE_SERVER_VERSION" value="10.5" />
-            <environmentVariable name="ECCUBE_AUTH_MAGIC" value="8PPlCHZVdH5vbMkIUKeuTeDHycQQMuaB" />
-            <environmentVariable name="ECCUBE_ADMIN_ALLOW_HOSTS" value="[]" />
-            <environmentVariable name="ECCUBE_FORCE_SSL" value="false" />
-            <environmentVariable name="ECCUBE_ADMIN_ROUTE" value="admin" />
-            <environmentVariable name="ECCUBE_COOKIE_PATH" value="/" />
-        </environmentVariables>
-    </application>
-<!-- /追加 -->
-</fastCgi>
-```
-
-[参考: IIS コンフィギュレーション リファレンス](https://msdn.microsoft.com/ja-jp/library/ee431592.aspx#EDA)
-
 ### サーバ設定ファイルに環境変数を設定した場合の注意事項
 
 サーバ設定ファイルに環境変数を設定した場合、 以下の機能を管理画面から設定することができません。


### PR DESCRIPTION
Eccube４系は、インターネット インフォメーション サービス (IIS) はサポートしていないため、こちらの記述は不要と判断し削除しています。