### PR TITLE
サブディレクトリのページでFaviconが表示されない不具合を修正。

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,6 +1,6 @@
 <!-- start custom head snippets -->
 
 <!-- insert favicons. use https://realfavicongenerator.net/ -->
-<link rel="shortcut icon" href="./assets/images/favicon.ico">
+<link rel="shortcut icon" href="/assets/images/favicon.ico">
 
 <!-- end custom head snippets -->


### PR DESCRIPTION
「./assets」で指定するとダメでした。
ページのルートからassetsを探しに行くので表示されます。

### 例) 表示されないページ
https://doc4.ec-cube.net/documents/request