### PR TITLE
本体インストール方法「Docker Composeを使用してインストールする」を追加

### DIFF
--- a/_pages/quickstart/install.md
+++ b/_pages/quickstart/install.md
@@ -225,7 +225,7 @@ docker-compose up -d
 `.env` にて `MAILER_URL=smtp://mailcatcher:1025` としておきます。
 
 ##### PostgreSQL を使用する場合
-`.env` にて `DATABASE_URL=pgsql://postgres:password@postgres/cube4_dev` としておきます。
+`.env` にて `DATABASE_URL=postgres://postgres:password@postgres/cube4_dev` としておきます。
 
 データベーススキーマを初期化していない場合は、以下の実行が必要です。
 ```

--- a/_pages/quickstart/install.md
+++ b/_pages/quickstart/install.md
@@ -181,8 +181,11 @@ docker run --name ec-cube -p "8080:80" -p "4430:443" --link container_mysql:db e
 ```shell
 cd path/to/ec-cube
 
+# .envファイルのコピー
+cp .env.dist .env
+
 # コンテナの起動 (初回のみビルド処理あり)
-docker-compose up
+docker-compose up -d
 
 # 初回はインストールスクリプトを実行
 docker-compose exec ec-cube bin/console eccube:install
@@ -191,7 +194,7 @@ docker-compose exec ec-cube bin/console eccube:install
 2回目以降の起動時も同様のコマンドを使用します。
 ```shell
 # コンテナの起動
-docker-compose up
+docker-compose up -d
 
 # コンテナの停止
 docker-compose down
@@ -200,17 +203,19 @@ docker-compose down
 #### 各種コンテナの使用
 EC-CUBE 4が動作するWebサーバを含め、以下のコンテナが簡単に起動できます。
 
-| コンテナ名       | 概要               | 
-|-------------|------------------|
-| ec-cube     | EC-CUBE 向けPHP Webサーバ   |  
-| mysql       | MySQLデータベースサーバ      |  
-| postgres    | PostgreSQLデータベースサーバ |  
-| mailcatcher | MailCatcher デバッグ用SMTPサーバ     |  
+| コンテナ名  | 概要                             | ブラウザアクセス例 |
+| ----------- | -------------------------------- | -------------------------- |
+| ec-cube     | EC-CUBE 向けPHP Webサーバ        | [http://localhost:8080](http://localhost:8080){:target="_blank"}      |
+| postgres    | PostgreSQLデータベースサーバ     |                            |
+| mysql       | MySQLデータベースサーバ          |                            |
+| pgweb     | PostgreSQL GUIツール             | [http://localhost:8082](http://localhost:8082){:target="_blank"}      |
+| phpMyAdmin  | MySQL GUIツール                  | [http://localhost:8081](http://localhost:8081){:target="_blank"}      |
+| mailcatcher | MailCatcher デバッグ用SMTPサーバ | [http://localhost:1080](http://localhost:1080){:target="_blank"}      |
 
 起動時にコンテナ名を列挙することで、各種コンテナを起動します。
 ```shell
-# 例：EC-CUBEとMySQLとMailCatcherを起動する
-docker-compose up -d ec-cube mysql mailcatcher
+# 例：EC-CUBEとMySQLとphpMyAdminとMailCatcherを起動する
+docker-compose up -d ec-cube mysql phpmyadmin mailcatcher
 
 # 省略した場合はすべてのサービスが起動します
 docker-compose up -d
@@ -219,24 +224,21 @@ docker-compose up -d
 ##### メール送信を使用する場合
 `.env` にて `MAILER_URL=smtp://mailcatcher:1025` としておきます。
 
-例：`localhost`上(デフォルトポート:1080)で構築した場合、以下URLにてアクセスします。
-
-[http://localhost:1080](http://localhost:1080)
-
-
 ##### PostgreSQL を使用する場合
-`.env` にて `DATABASE_URL=pgsql://dbuser:secret@postgres/eccubedb` としておきます。
+`.env` にて `DATABASE_URL=pgsql://postgres:password@postgres/cube4_dev` としておきます。
 
 データベーススキーマを初期化していない場合は、以下の実行が必要です。
 ```
+# スキーマ作成+初期データ投入
 docker-compose exec ec-cube composer run-script compile
 ```
 
 ##### MySQL を使用する場合
-`.env` にて `DATABASE_URL=mysql://dbuser:secret@postgres/eccubedb` としておきます。
+`.env` にて `DATABASE_URL=mysql://root:password@mysql/cube4_dev` としておきます。
 
 データベーススキーマを初期化していない場合は、以下の実行が必要です。
 ```
+# スキーマ作成+初期データ投入
 docker-compose exec ec-cube composer run-script compile
 ```
 

--- a/_pages/quickstart/install.md
+++ b/_pages/quickstart/install.md
@@ -15,6 +15,7 @@ EC-CUBEのインストールは、以下の方法があります。
 1. コマンドラインからインストールする
 1. Webインストーラでインストールする
 1. Dockerを使用してインストールする
+1. Docker Composeを使用してインストールする
 
 ### パッケージを使用してインストールする
 
@@ -167,6 +168,90 @@ docker run --name ec-cube -p "8080:80" -p "4430:443" --link container_postgres:d
 docker run --name container_mysql -e MYSQL_ROOT_PASSWORD=password  -d -p 3306:3306 mysql:5.7
 docker run --name ec-cube -p "8080:80" -p "4430:443" --link container_mysql:db eccube4-php-apache
 ```
+
+### Docker Composeを使用してインストールする
+**開発環境として関連サービス(DB、メールデバッグ環境等)も含め手軽に一括構築したい場合におすすめの方法です**
+
+前提として、 [Docker Desktop のインストール](https://hub.docker.com){:target="_blank"} が必要です。
+
++ 初期状態では SQLite3 を使用します
++ ローカルディレクトリをマウントします
+
+
+```shell
+cd path/to/ec-cube
+
+# コンテナの起動 (初回のみビルド処理あり)
+docker-compose up
+
+# 初回はインストールスクリプトを実行
+docker-compose exec ec-cube bin/console eccube:install
+```
+
+2回目以降の起動時も同様のコマンドを使用します。
+```shell
+# コンテナの起動
+docker-compose up
+
+# コンテナの停止
+docker-compose down
+```
+
+#### 各種コンテナの使用
+EC-CUBE 4が動作するWebサーバを含め、以下のコンテナが簡単に起動できます。
+
+| コンテナ名       | 概要               | 
+|-------------|------------------|
+| ec-cube     | EC-CUBE 向けPHP Webサーバ   |  
+| mysql       | MySQLデータベースサーバ      |  
+| postgres    | PostgreSQLデータベースサーバ |  
+| mailcatcher | MailCatcher デバッグ用SMTPサーバ     |  
+
+起動時にコンテナ名を列挙することで、各種コンテナを起動します。
+```shell
+# 例：EC-CUBEとMySQLとMailCatcherを起動する
+docker-compose up -d ec-cube mysql mailcatcher
+
+# 省略した場合はすべてのサービスが起動します
+docker-compose up -d
+```
+各種コンテナと連携させる場合は、以下の通り設定が必要です。
+##### メール送信を使用する場合
+`.env` にて `MAILER_URL=smtp://mailcatcher:1025` としておきます。
+
+例：`localhost`上(デフォルトポート:1080)で構築した場合、以下URLにてアクセスします。
+
+[http://localhost:1080](http://localhost:1080)
+
+
+##### PostgreSQL を使用する場合
+`.env` にて `DATABASE_URL=pgsql://dbuser:secret@postgres/eccubedb` としておきます。
+
+データベーススキーマを初期化していない場合は、以下の実行が必要です。
+```
+docker-compose exec ec-cube composer run-script compile
+```
+
+##### MySQL を使用する場合
+`.env` にて `DATABASE_URL=mysql://dbuser:secret@postgres/eccubedb` としておきます。
+
+データベーススキーマを初期化していない場合は、以下の実行が必要です。
+```
+docker-compose exec ec-cube composer run-script compile
+```
+
+
+#### ファイルの同期
+
+docker-composeを用いてインストールした場合、ホストのローカルディレクトリとコンテナ上のファイルは同期します。`.env`等の設定ファイルについても、ホスト上のファイルを直接編集します。
+
+なお、一部環境において著しいパフォーマンスの劣化が発生する場合があるため、以下のフォルダは同期の対象から除外しています。
+ - /var
+ - /vender  
+
+上記除外対象のフォルダについてはDocker Volumeを用いて別途永続化を行っています。
+
+
 
 ## 本番環境での .env ファイルの利用について
 


### PR DESCRIPTION
以下、DockerComposeを用いたインストールに対応するドキュメントを追加しました
https://github.com/EC-CUBE/ec-cube/pull/4391
https://github.com/EC-CUBE/ec-cube/pull/4397

## 相談
私見ではありますが、Dockerの知見があればDBなども揃えて開発環境を整えるのは一番早いかなと思いますので、下記一文を加えていますが、ぜひご意見をいただきたいです。
```
開発環境として関連サービス(DB、メールデバッグ環境等)も含め手軽に一括構築したい場合におすすめの方法です
```
また、基本的に本番環境ではなく開発環境を想定しています。
