### PR TITLE
ページを編集するリンク追加

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -13,7 +13,7 @@
 
 <!-- For all browsers -->
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
-<link rel="stylesheet" href="/assets/font-awesome-4.7.0/css/font-awesome.min.css">
+<link rel="stylesheet" href="{{ '/assets/font-awesome-4.7.0/css/font-awesome.min.css' | relative_url }}">
 <!--[if IE ]>
   <style>
     /* old IE unsupported flexbox fixes */

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -41,6 +41,7 @@ layout: default
               ページを評価/質問する
               <img src="//c.disquscdn.com/next/current/publisher-admin/assets/img/emoji/sad-512x512.png" style="height: 24px;width: 24px;">
             </a>
+            {% github_edit_link '<i class="fa fa-pencil-square-o" aria-hidden="true"></i> ページを編集する' %}
             <nav class="toc">
               <header><h4 class="nav__title"><i class="fas fa-{{ page.toc_icon | default: 'file-alt' }}"></i> {{ page.toc_label | default: site.data.ui-text[site.locale].toc_label | default: "On this page" }}</h4></header>
               {% include toc.html sanitize=true html=content h_min=1 h_max=6 class="toc__menu" %}


### PR DESCRIPTION
## 概要
GitHub上で直接ページを編集してPRを作成できるリンクを追加しました。

![image](https://user-images.githubusercontent.com/57504/74714739-89342e80-526e-11ea-924b-518be15b7d77.png)

## 参考情報
http://jekyll.github.io/github-metadata/edit-on-github-link/