### PR TITLE
navigation.yml のカテゴリの名称を「多言語化」から、より汎用的な「設定変更」に修正

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -120,7 +120,7 @@ docs:
         url: /plugin_sample
         output: web, pdf
 
-  - title: 多言語化
+  - title: 設定変更
     output: web, pdf
     children:
       - title: 多言語化


### PR DESCRIPTION
できればファイル配置が _pages/i18n/ となっているのもやめたかったが影響が大きそうだったので取り急ぎサイドナビだけ修正しました。