### PR TITLE
タイトルが違っていたところを変更しました。

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -64,7 +64,7 @@ docs:
       - title: FormTypeのカスタマイズ
         url: /customize_formtype
         output: web, pdf
-      - title: Serviceのカスタマイズ
+      - title: 購入フローのカスタマイズ
         url: /customize_service
         output: web, pdf
       - title: テンプレートのカスタマイズ

--- a/_pages/customize/customize_service.md
+++ b/_pages/customize/customize_service.md
@@ -1,5 +1,5 @@
 ---
-title: PurchaseFlow のカスタマイズ
+title: 購入フローのカスタマイズ
 keywords: core カスタマイズ PurchaseFlow Cart Shopping
 tags: [core, service, purchaseflow]
 permalink: customize_service

--- a/index.md
+++ b/index.md
@@ -46,7 +46,7 @@ EC-CUBEのインストール方法、開発ガイドラインや要素技術の�
 + [Entityのカスタマイズ](customize_entity)
 + [Repositoryのカスタマイズ](customize_repository)
 + [FormTypeのカスタマイズ](customize_formtype)
-+ [Serviceのカスタマイズ](customize_service)
++ [購入フローのカスタマイズ](customize_service)
 + [テンプレートのカスタマイズ](customize_template)
 + [Symfonyの機能を使った拡張](customize_symfony)
 


### PR DESCRIPTION
[左メニューの項目名と、実際のページのタイトルが、食い違っている #84](https://github.com/EC-CUBE/doc4.ec-cube.net/issues/84#issue-604457036)

こちらの修正しました。