### PR TITLE
公式サイトの開発協力ページへのリンクを追加

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -144,9 +144,12 @@ docs:
       - title: MailCatcher
         url: /development-tools/mail-catcher
         output: web, pdf
-  - title: 本体開発に参加する
+  - title: 開発に参加する
     output: web, pdf
     children:
+    - title: EC-CUBEの開発に参加するには？（公式サイト）
+      url: https://www.ec-cube.net/committer/
+      output: web, pdf
     - title: 開発の概要
       url: /contribution-guide/overview
       output: web, pdf

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -176,3 +176,6 @@ docs:
       - title: ドキュメントの投稿
         url: /documents/contribute
         output: web, pdf
+      - title: ドキュメントへのフィードバック
+        url: https://www.ec-cube.net/committer/#Doc4Form
+        output: web, pdf

--- a/index.md
+++ b/index.md
@@ -80,7 +80,8 @@ EC-CUBEのインストール方法、開発ガイドラインや要素技術の�
 ## Web API仕様（ベータ）
 + [Web API β版 スタートアップガイド](api_quickstart_guide)
 
-## 本体開発に参加する
+## 開発に参加する
++ [EC-CUBEの開発に参加するには？（公式サイト）](https://www.ec-cube.net/committer/){:target="_blank"}
 + [開発の概要](/contribution-guide/overview)
 + [プルリクエストの作り方](/contribution-guide/pull-request)
 

--- a/index.md
+++ b/index.md
@@ -16,6 +16,7 @@ EC-CUBEのインストール方法、開発ガイドラインや要素技術の�
 + EC-CUBE本体と同様に[GitHub](https://github.com/EC-CUBE/doc4.ec-cube.net/){:target="_blank"}へIssueをご投稿いただく
   詳細は[こちら](documents/request)をご覧ください
 + [実施予定のUGや勉強会](https://www.ec-cube.net/event/){:target="_blank"}を探して参加する
++ [ドキュメントへの要望を送る（公式サイト）](https://www.ec-cube.net/committer/#Doc4Form){:target="_blank"}
 
 ドキュメントへの追記、記載内容の修正についても[GitHub](https://github.com/EC-CUBE/doc4.ec-cube.net/){:target="_blank"}にて受け付けております。
 追加方法は[こちら](/documents/writing-and-formatting)をご覧ください。
@@ -23,6 +24,8 @@ EC-CUBEのインストール方法、開発ガイドラインや要素技術の�
 運用者向けには以下のサイトをご覧ください。
 
 + [EC-CUBE 4管理・運用 マニュアル（株式会社シロハチ様）](https://www.shiro8.net/manual4/v40x/index.html){:target="_blank"}
+
+[こちら](https://www.ec-cube.net/committer/#Doc4Form){:target="_blank"}でドキュメントへのフィードバックを募集しています。
 
 ## Quick Start
 
@@ -89,6 +92,7 @@ EC-CUBEのインストール方法、開発ガイドラインや要素技術の�
 + [ドキュメントのリクエスト](/documents/request)
 + [ドキュメントの追加・書き方](/documents/writing-and-formatting)
 + [ドキュメントの投稿](/documents/contribute)
++ [ドキュメントへのフィードバックを送る](https://www.ec-cube.net/committer/#Doc4Form){:target="_blank"}
 
 ## Supporters
 


### PR DESCRIPTION
公式サイトの開発協力ページへのリンクを追加しました。
プラグインなどの開発にも同様の手順で参加できるので、「本体」の文言は消しました。