### PR TITLE
SameSite_Cookieへのリンクが切れていたので修正しました。

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -32,7 +32,7 @@ docs:
         url: /update/4_0_3
         output: web, pdf
       - title: SameSite Cookie 対応
-        url: /update/hotfix_samesite_cookie
+        url: /hotfix_samesite_cookie
         output: web, pdf
   - title: 機能仕様
     output: web, pdf


### PR DESCRIPTION
サイドナビのSameSite_Cookieへのリンクが切れていたので修正しました。