### PR TITLE
タイポ修正 (forder -> folder)

### DIFF
--- a/_pages/development-tools/mail-catcher.md
+++ b/_pages/development-tools/mail-catcher.md
@@ -3,7 +3,7 @@ title: MailCatcher
 keywords: mailcatcher
 tags: [development-tools, mail-catcher]
 permalink: /development-tools/mail-catcher
-forder: development-tools
+folder: development-tools
 ---
 
 ## 概要

--- a/_pages/i18n/currency.md
+++ b/_pages/i18n/currency.md
@@ -3,7 +3,7 @@ title: 通貨
 keywords: currency
 tags: [i18n, currency]
 permalink: i18n_currency
-forder: i18n
+folder: i18n
 
 ---
 

--- a/_pages/i18n/debug_mode.md
+++ b/_pages/i18n/debug_mode.md
@@ -3,7 +3,7 @@ title: デバッグモード
 keywords: debug
 tags: [debug, env]
 permalink: debug_mode
-forder: i18n
+folder: i18n
 
 ---
 

--- a/_pages/i18n/environmental_setting.md
+++ b/_pages/i18n/environmental_setting.md
@@ -3,7 +3,7 @@ title: 環境設定
 keywords: debug
 tags: [debug, env]
 permalink: environmental_setting
-forder: i18n
+folder: i18n
 
 ---
 

--- a/_pages/i18n/multilingualization.md
+++ b/_pages/i18n/multilingualization.md
@@ -3,7 +3,7 @@ title: 多言語化
 keywords: multilingualization
 tags: [i18n, multilingualization]
 permalink: i18n_multilingualization
-forder: i18n
+folder: i18n
 
 ---
 

--- a/_pages/i18n/timezone.md
+++ b/_pages/i18n/timezone.md
@@ -3,7 +3,7 @@ title: タイムゾーン
 keywords: timezone
 tags: [i18n, currency]
 permalink: i18n_timezone
-forder: i18n
+folder: i18n
 
 ---
 

--- a/_pages/quickstart/cli.md
+++ b/_pages/quickstart/cli.md
@@ -3,7 +3,7 @@ title: コマンドラインインターフェイス
 keywords: CLI
 tags: [quickstart, cli]
 permalink: quickstart_cli
-forder: quickstart
+folder: quickstart
 ---
 
 EC-CUBEでは、コマンドラインで実行できる各種ユーティリティコマンドを提供しています。

--- a/_pages/quickstart/gui_mac_install.md
+++ b/_pages/quickstart/gui_mac_install.md
@@ -3,7 +3,7 @@ title: Mac環境でMAMPを使用したインストール方法
 keywords: install MAMP
 tags: [quickstart, install, gui]
 permalink: quickstart_install/gui_mac_install
-forder: quickstart
+folder: quickstart
 description: EC-CUBE4系をMAMPを使用してMacのローカル環境へインストールする方法を解説します。
 ---
 

--- a/_pages/quickstart/gui_win_install.md
+++ b/_pages/quickstart/gui_win_install.md
@@ -3,7 +3,7 @@ title: Windows環境でXAMPPを使用したインストール方法
 keywords: install XAMPP
 tags: [quickstart, install, gui]
 permalink: quickstart_install/gui_win_install
-forder: quickstart
+folder: quickstart
 description: EC-CUBE4系をXAMPPを使用してWindowsのローカル環境へインストールする方法を解説します。
 ---
 

--- a/_pages/quickstart/install.md
+++ b/_pages/quickstart/install.md
@@ -4,7 +4,7 @@ title: インストール方法
 keywords: install
 tags: [quickstart, install]
 permalink: quickstart_install
-forder: quickstart/quickstart_install
+folder: quickstart/quickstart_install
 description: EC-CUBE 4系のインストールについての説明です。
 ---
 

--- a/_pages/quickstart/permission.md
+++ b/_pages/quickstart/permission.md
@@ -4,7 +4,7 @@ title: パーミッションの設定について
 keywords: permission
 tags: [quickstart, permission]
 permalink: permission
-forder: quickstart/permission
+folder: quickstart/permission
 description: パーミッション設定に関して
 ---
 

--- a/_pages/quickstart/web-installer.md
+++ b/_pages/quickstart/web-installer.md
@@ -3,7 +3,7 @@ title: Webインストーラでインストールする
 keywords: install
 tags: [quickstart, install]
 permalink: quickstart_install/web-installer
-forder: quickstart
+folder: quickstart
 description: EC-CUBE 4系のインストールについての説明です。
 ---
 


### PR DESCRIPTION
タイポ修正 (forder -> folder)

Jekyll のドキュメントに folder or forder パラメータについての記載は見当たらなかったが、 folder が正しいだろうということでfolderに統一しました。

