### PR TITLE
Entity拡張をデータベースへ反映する際はキャッシュ削除が必要な旨を明記

### DIFF
--- a/_pages/customize/customize_entity.md
+++ b/_pages/customize/customize_entity.md
@@ -46,6 +46,9 @@ bin/console eccube:generate:proxies
 Proxy を生成できたら、 `bin/console doctrine:schema:update` コマンドで、定義をデータベースに反映します。
 
 ```
+## 作成した Proxy クラスを確実に認識できるようキャッシュを削除
+bin/console cache:clear --no-warmup
+
 ## 実行する SQL を確認
 bin/console doctrine:schema:update --dump-sql
 


### PR DESCRIPTION
Proxy を生成した後、それをデータベースへ反映する際はキャッシュクリアが必要のようです。
（キャッシュクリアを行わないとDoctrineがEntiryの拡張を認識しませんでした）

その旨をドキュメントに明記すると良いと思います。
ご検討よろしくお願いします！（私は1日ハマりました…）