### PR TITLE
`bin/console server:run` はdevでないと使えないので `--env=dev` を付与

### DIFF
--- a/_pages/quickstart/install.md
+++ b/_pages/quickstart/install.md
@@ -65,11 +65,11 @@ php composer.phar create-project ec-cube/ec-cube ec-cube "4.0.x-dev" --keep-vcs
 
 
 4.ec-cube ディレクトリが生成されますので、`cd ec-cube`で移動し、  
-`bin/console server:run` コマンドを実行すると、ビルトインウェブサーバが起動します。
+`bin/console server:run --env=dev` コマンドを実行すると、ビルトインウェブサーバが起動します。
 
 ```shell
 cd ec-cube
-bin/console server:run
+bin/console server:run --env=dev
 ```
 
 5.[http://127.0.0.1:8000/admin](http://127.0.0.1:8000/admin) にアクセスし、 EC-CUBE の管理ログイン画面が表示されればインストール成功です。  


### PR DESCRIPTION
EC-CUBEはデフォルトでprodでインストールされるようになった。
`bin/console server:run` はdevでないと使えないので、 `--env=dev` を付与しました。

refs https://github.com/EC-CUBE/ec-cube/pull/4699