### PR TITLE
サンプルコードのuseのパスが間違っていたのを修正

### DIFF
--- a/_pages/customize/customize_order_state_machine.md
+++ b/_pages/customize/customize_order_state_machine.md
@@ -35,7 +35,7 @@ folder: customize
     - `workflow.order.transition.return` イベントを受け取る `EventSubscriberInterface` を実装します。
 
 ```php
-use Composer\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Eccube\Entity\Order;
 use Symfony\Component\Workflow\Event\Event;
 


### PR DESCRIPTION
ステートマシン説明ページのサンプルコードですが、useのパスが間違っていたので動きませんでした。
修正したコードを送ります。