### PR TITLE
$app['orm.em']を$this->entityMangerに変更

### DIFF
--- a/_pages/customize/customize_entity.md
+++ b/_pages/customize/customize_entity.md
@@ -69,8 +69,8 @@ public function index()
     dump($Product->maker_name);
 
     $Product->maker_name = 'あああ';
-    $app['orm.em']->persist($Product);
-    $app['orm.em']->flush();
+    $this->entityManger->persist($Product);
+    $this->entityManger->flush();
     ...
 ```
 


### PR DESCRIPTION
Applicationは4.1で削除されるしApplicationのインジェクションの記述もないため、
$app['orm.em']を$this->entityMangerに変更しました。