### PR TITLE
.env ファイルの利用についての項目が埋もれていたので別ページを作成

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -32,6 +32,8 @@ docs:
         output: web, pdf
       - title: パーミッションの設定について（共通事項）
         url: /permission
+      - title: 本番環境での .env ファイルの利用について（共通事項）
+        url: /quickstart_install/dotenv
         output: web, pdf
       - title: コマンドラインインターフェイス
         url: /quickstart_cli

--- a/_pages/quickstart/dotenv.md
+++ b/_pages/quickstart/dotenv.md
@@ -1,0 +1,63 @@
+---
+layout: single
+title: インストール方法
+keywords: install
+tags: [quickstart, install, dotenv]
+permalink: quickstart_install/dotenv
+folder: quickstart
+description: 本番環境での .env ファイルの利用についての説明です。
+---
+
+## 本番環境での .env ファイルの利用について
+
+インストール完了後、インストールディレクトリにデータベースの接続情報等が設定された **.env** ファイルが生成されます。
+**.env** ファイルは、開発用途での環境変数を設定するためのものであり、本番環境での使用は推奨されません。
+本番環境では、環境変数をサーバ設定ファイルに設定することを推奨します。
+サーバ設定ファイルに環境変数を設定することにより、環境変数が外部に暴露される危険性が減り、安全に運用できます。
+
+### Apache での設定例
+
+httpd.conf や、 .htaccess ファイルに設定します。
+
+```
+SetEnv APP_ENV prod
+SetEnv APP_DEBUG 0
+SetEnv DATABASE_URL pgsql://dbuser:password@127.0.0.1/cube4_dev
+SetEnv DATABASE_SERVER_VERSION 10.5
+SetEnv ECCUBE_AUTH_MAGIC 8PPlCHZVdH5vbMkIUKeuTeDHycQQMuaB
+SetEnv ECCUBE_ADMIN_ALLOW_HOSTS []
+SetEnv ECCUBE_FORCE_SSL false
+SetEnv ECCUBE_ADMIN_ROUTE admin
+SetEnv ECCUBE_COOKIE_PATH /
+```
+
+[参考: Apache HTTP サーバ バージョン 2.4 - SetEnv ディレクティブ](https://httpd.apache.org/docs/2.4/ja/mod/mod_env.html#setenv){:target="_blank"}
+
+### サーバ設定ファイルに環境変数を設定した場合の注意事項
+
+サーバ設定ファイルに環境変数を設定した場合、 以下の機能を管理画面から設定することができません。
+
+**サーバ設定ファイルの環境変数を変更し、キャッシュクリアする必要がありますのでご注意ください。**
+
+- 管理画面→オーナーズストア→テンプレート
+- 管理画面→設定→システム設定→セキュリティ管理
+
+### bin/console コマンドの使用について
+
+`bin/console` コマンドを使用する場合、通常は .env ファイルから環境変数を取得します。
+.env を使用しない場合は、 shell の環境変数に設定をします。
+この場合、 `.bashrc` などの shell の設定ファイルのパーミッションは 600 など、オーナー以外は読み書きできない設定にしておくことを強く推奨します。
+
+```
+## .bashrc の設定例
+export APP_ENV="prod"
+export APP_DEBUG="0"
+export DATABASE_URL="pgsql://dbuser:password@127.0.0.1/cube4_dev"
+export DATABASE_SERVER_VERSION="10.5"
+export ECCUBE_AUTH_MAGIC="8PPlCHZVdH5vbMkIUKeuTeDHycQQMuaB"
+export ECCUBE_ADMIN_ALLOW_HOSTS="[]"
+export ECCUBE_FORCE_SSL="false"
+export ECCUBE_ADMIN_ROUTE="admin"
+export ECCUBE_COOKIE_PATH="/"
+```
+

--- a/_pages/quickstart/install.md
+++ b/_pages/quickstart/install.md
@@ -34,6 +34,12 @@ description: EC-CUBE 4系のインストールについての説明です。
 インストールした際の[パーミッションの設定について](/permission)も合わせてお読みください。  
 セキュリティの観点から、パーミッションは可能な限り制限して特定のディレクトリ・ファイルのみに書き込み権限を与えることをおすすめいたします。
 
+#### 本番環境での .env ファイルの利用について
+
+[本番環境にインストールする場合の .env ファイルの利用について](/quickstart_install/dotenv)も合わせてお読みください。
+セキュリティの観点から、本番環境での .env ファイルの利用は推奨されません。
+本番環境では、環境変数をサーバ設定ファイルに設定することを推奨します。
+
 ---
 
 ### 1.コマンドラインからインストールする
@@ -289,39 +295,3 @@ docker-composeを用いてインストールした場合、ホストのローカ
  - /vendor  
 
 上記除外対象のフォルダについてはDocker Volumeを用いて別途永続化を行っています。
-
-
-
-## 本番環境での .env ファイルの利用について
-
-インストール完了後、インストールディレクトリにデータベースの接続情報等が設定された **.env** ファイルが生成されます。
-**.env** ファイルは、開発用途での環境変数を設定するためのものであり、本番環境での使用は推奨されません。
-本番環境では、環境変数をサーバ設定ファイルに設定することを推奨します。
-サーバ設定ファイルに環境変数を設定することにより、環境変数が外部に暴露される危険性が減り、安全に運用できます。
-
-### Apache での設定例
-
-httpd.conf や、 .htaccess ファイルに設定します。
-
-```
-SetEnv APP_ENV prod
-SetEnv APP_DEBUG 0
-SetEnv DATABASE_URL pgsql://dbuser:password@127.0.0.1/cube4_dev
-SetEnv DATABASE_SERVER_VERSION 10.5
-SetEnv ECCUBE_AUTH_MAGIC 8PPlCHZVdH5vbMkIUKeuTeDHycQQMuaB
-SetEnv ECCUBE_ADMIN_ALLOW_HOSTS []
-SetEnv ECCUBE_FORCE_SSL false
-SetEnv ECCUBE_ADMIN_ROUTE admin
-SetEnv ECCUBE_COOKIE_PATH /
-```
-
-[参考: Apache HTTP サーバ バージョン 2.4 - SetEnv ディレクティブ](https://httpd.apache.org/docs/2.4/ja/mod/mod_env.html#setenv){:target="_blank"}
-
-### サーバ設定ファイルに環境変数を設定した場合の注意事項
-
-サーバ設定ファイルに環境変数を設定した場合、 以下の機能を管理画面から設定することができません。
-
-**サーバ設定ファイルの環境変数を変更し、キャッシュクリアする必要がありますのでご注意ください。**
-
-- 管理画面→オーナーズストア→テンプレート
-- 管理画面→設定→システム設定→セキュリティ管理

--- a/index.md
+++ b/index.md
@@ -40,6 +40,7 @@ EC-CUBEのインストール方法、開発ガイドラインや要素技術の�
 + [Mac環境でMAMPを使用したインストール](/quickstart_install/gui_mac_install)
 + [開発者向けインストール方法](quickstart_install)
 + [パーミッションの設定について](permission)
++ [本番環境での .env ファイルの利用について](/quickstart_install/dotenv)
 + [コマンドラインインターフェイス](quickstart_cli)
 
 ## バージョンアップ


### PR DESCRIPTION
開発者向けインストールの中に埋もれていた