### PR TITLE
アップデート手順のプロキシ削除の手順を修正

### DIFF
--- a/_pages/quickstart/update.md
+++ b/_pages/quickstart/update.md
@@ -153,7 +153,7 @@ bin/console doctrine:migrations:migrate
 
 プロキシファイルを削除
 ```
-rm -f app/proxy/entity/*.php
+rm -rf app/proxy/entity/*
 ```
 
 autoloadファイルの再生成


### PR DESCRIPTION
アップデート手順のプロキシ削除の手順を修正
プロキシファイルは `app/proxy/entity/` 直下に生成されなくなった
