### PR TITLE
namespaceは内部的に管理しているものなのでドキュメントには不要

### DIFF
--- a/_pages/co/co_naming_rules.md
+++ b/_pages/co/co_naming_rules.md
@@ -15,7 +15,5 @@ folder: co
 |-|-|-|
 |リポジトリ名|eccube.co-[shopid]-customize||
 |ブランチ|master->本番環境, develop->テスト環境|※ スタンダードプランのみ|
-|namespace(本番環境)|[shopid]||
-|namespace(テスト環境)|stg-[shopid]|※ スタンダードプランのみ|
 |ショップURL(本番環境)|[shopid].ec-cuube.shop||
 |ショップURL(テスト環境)|stg-[shopid].ec-cuube.shop|※ スタンダードプランのみ|


### PR DESCRIPTION
coの内部的な管理に利用しているものなのでユーザーが意識するものではない。
PHPのnamespaceと混乱するので削除。