### PR TITLE
4.1マイグレーションガイドのオーナーズストア経由でのプラグインインストールテストを修正しました。

### DIFF
--- a/_pages/quickstart/update_40_41.md
+++ b/_pages/quickstart/update_40_41.md
@@ -321,10 +321,10 @@ Eccube\Applicationは削除されました。これに伴い、ServiceProvider �
 ## オーナーズストア経由でのプラグインインストールテスト
 
 EC-CUBE 4.1 では Composer2 対応が必要となりました。
-それに伴い EC-CUBE がオーナーズストア経由でプラグインをインストールする際にのエンドポイントが変更になっています。
-EC-CUBE 4.1 beta2 以前でテストをしたい場合は、EC-CUBE に以下の環境変数を設定することで Composer2 対応のエンドポイントへ切り替えられます。
-EC-CUBE 4.1 RC 以降ではこちらの対応は不要となる予定です。
+それに伴い EC-CUBE がオーナーズストア経由でプラグインをインストールする際のエンドポイントが変更になっています。
+EC-CUBE 4.1 beta3 以前でテストをしたい場合は、EC-CUBE に以下の環境変数を設定することで Composer2 対応のエンドポイントへ切り替えられます。
+GitHub の最新の 4.1 ブランチではこちらの対応は不要です。
 
 ```
-ECCUBE_PACKAGE_API_URL=https://stg-c2-package-api.ec-cube.net
+ECCUBE_PACKAGE_API_URL=https://package-api-c2.ec-cube.net
 ```


### PR DESCRIPTION
4.1マイグレーションガイドのオーナーズストア経由でのプラグインインストールテストを修正しました。

package-api の URL が間違っていました。
また EC-CUBE 4.1-beta3 のリリースに伴い、文言を修正しました。