### PR TITLE
Git管理対象となるディレクトリの表現を修正

### DIFF
--- a/_pages/co/co_git.md
+++ b/_pages/co/co_git.md
@@ -15,23 +15,15 @@ folder: co
 |-----------------------------------------------|-------------|----------------------------|----------------|
 | \|\-\- app                                  　|             |                            |                |
 | \|&emsp;&emsp;\|\-\- Customize                | o           |                            |                |
-| \|&emsp;&emsp;\|&emsp;&emsp;\|\-\- Controller | o           |                            |                |
-| \|&emsp;&emsp;\|&emsp;&emsp;\|-- Entity       | o           |                            |                |
-| \|&emsp;&emsp;\|&emsp;&emsp;`\-\- Resource    | o           |                            |                |
 | \|&emsp;&emsp;\|\-\- DoctrineMigrations       | x           |                            |                |
 | \|&emsp;&emsp;\|\-\- Plugin                   | x           | o                          |                |
 | \|&emsp;&emsp;\|\-\- PluginData               | x           | o                          |                |
 | \|&emsp;&emsp;\|\-\- config                   | x           |                            |                |
 | \|&emsp;&emsp;\|\-\- proxy                    | x           |                            |                |
 | \|&emsp;&emsp;`\-\- template                  | o           | o                          | o               |
-| \|&emsp;&emsp;&emsp;&emsp;\|\-\- admin        | o           | o                          |               |
-| \|&emsp;&emsp;&emsp;&emsp;\|\-\- default      |  o          | o                          | o              |
-| \|&emsp;&emsp;&emsp;&emsp;`\-\- user_data     |  o          | o                          | o              |
 | `\-\- html                                    |             |                            |                |
 |&emsp;&emsp;\|\-\- plugin            　　　　   |  o          | o                          |               |
 |&emsp;&emsp;\|\-\- template           　　　　  |  o          | o                          | o              |
-|&emsp;&emsp;\|&emsp;&emsp;\|\-\- admin         |  o          | o                          |               |
-|&emsp;&emsp;\|&emsp;&emsp;`\-\- default        |  o          | o                          |               |
 |&emsp;&emsp;\|\-\- upload             　　　 　  |  x       　 |                            |                |
 |&emsp;&emsp;\|&emsp;&emsp;\|\-\- save_image    |  x          |                            |  o              |
 |&emsp;&emsp;\|&emsp;&emsp;`\-\- temp_image     |  x          |                            |  o              |
@@ -40,7 +32,7 @@ folder: co
 
 ## 表の見方 
 
-1. デプロイ対象：gitの管理、ソースコードの反映が可能なリソース
+1. Git管理対象：Gitによるソースコードやディレクトリの反映が可能なリソース
 1. Plugin利用による影響：<br>PluginのInstall/UnInstall/enable/disable/実行時の操作、などによりソースコードが書き換えられる可能性のあるリソース
 1. 管理画面からの操作：管理画面でなんからの更新が行われるリソース（ページ/テンプレート管理など）
 


### PR DESCRIPTION
app > Customize
app > template
html > template

の配下はファイルやディレクトリを新規作成してGit管理されるため、サブディレクトリの表記を削除。
またディレクトリもGit管理対象であることを説明に追加。

![キャプチャ](https://user-images.githubusercontent.com/18630259/132808176-0c2c4bbe-ce4d-4883-a832-4001e9a82337.png)
