### PR TITLE
バージョンアップのメニューとタイトル整頓

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -71,7 +71,13 @@ docs:
   - title: バージョンアップ
     output: web, pdf
     children:
-      - title: バージョンアップ方法
+      - title: 4.0から4.1への本体バージョンアップ
+        url: /update41
+        output: web, pdf
+      - title: 4.0から4.1へのマイグレーション
+        url: /update-40-41
+        output: web, pdf
+      - title: 4.0本体バージョンアップ
         url: /update
         output: web, pdf
       - title: 4.0.3での注意点
@@ -79,12 +85,6 @@ docs:
         output: web, pdf
       - title: SameSite Cookie 対応
         url: /hotfix_samesite_cookie
-        output: web, pdf
-      - title: EC-CUBE4.0から4.1へのマイグレーション
-        url: /update-40-41
-        output: web, pdf
-      - title: EC-CUBE本体のバージョンアップ
-        url: /update41
         output: web, pdf
 
   - title: 機能仕様

--- a/_pages/quickstart/update.md
+++ b/_pages/quickstart/update.md
@@ -4,7 +4,7 @@ title: 4.0本体バージョンアップ
 keywords: howto update
 tags: [quickstart, getting_started]
 permalink: update
-summary : EC-CUBE4.0.0から4.0.6-p1への本体バージョンアップ手順について記載します。
+summary : 4.0.0から4.0.6-p1への本体バージョンアップ手順について記載します。
 ---
 
 本番環境でバージョンアップを行う前に、テスト環境で事前検証を必ず行ってください。

--- a/_pages/quickstart/update.md
+++ b/_pages/quickstart/update.md
@@ -1,10 +1,10 @@
 ---
 layout: single
-title: EC-CUBE本体のバージョンアップ
+title: 4.0本体バージョンアップ
 keywords: howto update
 tags: [quickstart, getting_started]
 permalink: update
-summary : EC-CUBE本体のバージョンアップ手順について記載します。
+summary : EC-CUBE4.0.0から4.0.6-p1への本体バージョンアップ手順について記載します。
 ---
 
 本番環境でバージョンアップを行う前に、テスト環境で事前検証を必ず行ってください。

--- a/_pages/quickstart/update41.md
+++ b/_pages/quickstart/update41.md
@@ -1,10 +1,10 @@
 ---
 layout: single
-title: EC-CUBE本体のバージョンアップ
+title: 4.0から4.1への本体バージョンアップ
 keywords: howto update
 tags: [quickstart, getting_started]
 permalink: update41
-summary : EC-CUBE4.0から4.1へのバージョンアップ手順について記載します。
+summary : EC-CUBE4.0から4.1への本体バージョンアップ手順について記載します。
 ---
 
 本番環境でバージョンアップを行う前に、テスト環境で事前検証を必ず行ってください。

--- a/_pages/quickstart/update_40_41.md
+++ b/_pages/quickstart/update_40_41.md
@@ -1,6 +1,6 @@
 ---
 layout: single
-title: EC-CUBE4.0から4.1へのマイグレーション
+title: 4.0から4.1へのマイグレーション
 keywords: howto update
 tags: [quickstart, getting_started]
 permalink: update-40-41


### PR DESCRIPTION
- 4.1へのバージョンアップページをメニューで上の方に表示するように変更。
- タイトルをわかりやすいように変更。