### PR TITLE
べた書きになっていたURLをリンクへ修正

### DIFF
--- a/_pages/customize/customize_controller.md
+++ b/_pages/customize/customize_controller.md
@@ -285,4 +285,4 @@ Content-Type: text/plain; charset=utf-8
 EC-CUBE 4 ではSymfonyのController機構を利用しています。  
 その他のカスタマイズ方法についてはSymfonyのドキュメントを参照してください。
 
-https://symfony.com/doc/current/controller.html
+[Controller](https://symfony.com/doc/current/controller.html){:target="_blank"}


### PR DESCRIPTION
「Controllerのカスタマイズ」ページでURLがベタ書きになっていた部分をリンク化しました。