### PR TITLE
Macでプラグインアーカイブ時に `._` で始まるファイルを含めないようにする

### DIFF
--- a/_pages/plugin/spec.md
+++ b/_pages/plugin/spec.md
@@ -134,7 +134,7 @@ Twigファイルからこの `sample.jpg` へのパスは以下の記述で取�
 
 ```bash
 $ cd app/Plugin/[PluginDir]
-$ tar --exclude  ".git" --exclude ".DS_Store" -cvzf ../[PluginDir].tar.gz *
+$ COPYFILE_DISABLE=1 tar --exclude  ".git" --exclude ".DS_Store" -cvzf ../[PluginDir].tar.gz *
 ```
 
 ## 3.0.xからの変更点


### PR DESCRIPTION
Macでプラグインをアーカイブしたときに `._PluginManager.php` のような `._` で始まるファイルがアーカイブに含まれることがある。
これらのファイルが含まれると環境によってはエラーが発生してしまうので、環境変数 `COPYFILE_DISABLE` を指定して `._` ファイルが含まれないようにする。