### PR TITLE
ビルドエラー解消のため、config.yml から theme を削除

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,6 @@
 # Review documentation to determine if you should use `theme` or `remote_theme`
 # https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/#installing-the-theme
 
-theme                  : "minimal-mistakes-jekyll"
 remote_theme           : "mmistakes/minimal-mistakes@4.16.5"
 minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 


### PR DESCRIPTION
config.yml にて `theme` と `remote_theme` の両方を指定していると、GitHub Actions でのビルド時に以下のエラーとなるため、config から theme を削除しました

```
github-pages 222 | Error:  The minimal-mistakes-jekyll theme could not be found.
```