### PR TITLE
動作確認ブラウザからOSバージョン表記削除

### DIFF
--- a/_pages/quickstart/requirement.md
+++ b/_pages/quickstart/requirement.md
@@ -33,9 +33,9 @@ permalink: quickstart/requirement
 
 | OS | ブラウザ|
 |---|-------|
-|Windows(Windows10以降) | Edge 最新 |
+|Windows | Edge 最新 |
 ||FireFox 最新 |
 ||Google Chrome 最新 |
-|Mac(OS X以降)|Safari 最新|
-|iOS (10以降)|Safari 最新|
-|Android (4.4以降)| 標準ブラウザ 最新|
+|Mac|Safari 最新|
+|iOS|Safari 最新|
+|Android| 標準ブラウザ 最新|


### PR DESCRIPTION
[252](https://github.com/EC-CUBE/doc4.ec-cube.net/pull/252)で話題に上がった、OSバージョンの表記が不要というコメントを受けて削除しました。