### PR TITLE
EC-CUBE4.2.0のソフトウェア要件（必須PHPライブラリ）などのドキュメントの修正

### DIFF
--- a/_pages/quickstart/requirement.md
+++ b/_pages/quickstart/requirement.md
@@ -36,8 +36,10 @@ permalink: quickstart/requirement
 
 | 分類 | ライブラリ|
 |---|---|
-|必須ライブラリ|pgsql / mysqli (利用するデータベースに合わせること) <br> pdo_pgsql / pdo_mysql / pdo_sqlite (利用するデータベースに合わせること) <br> pdo <br> phar <br> mbstring <br> zlib <br> ctype <br> session <br> JSON <br> xml <br> libxml <br> OpenSSL <br> zip <br> cURL <br> fileinfo <br> intl <br> GD |
+|必須ライブラリ|pgsql / mysqli (利用するデータベースに合わせること) <br> pdo_pgsql / pdo_mysql / pdo_sqlite (利用するデータベースに合わせること) <br> pdo <br> phar <br> mbstring <br> zlib <br> ctype <br> session <br> JSON <br> xml <br> libxml <br> OpenSSL <br> zip <br> cURL <br> fileinfo <br> intl <br> GD <br> Sodium(※4) |
 |推奨ライブラリ|hash <br> APCu / WinCache (利用する環境に合わせること) <br> Zend OPcache |
+
+※4 EC-CUBE 4.2系は Sodium拡張 が必要になります。
 
 # 動作確認ブラウザ
 

--- a/_pages/quickstart/requirement.md
+++ b/_pages/quickstart/requirement.md
@@ -39,7 +39,7 @@ permalink: quickstart/requirement
 |必須ライブラリ|pgsql / mysqli (利用するデータベースに合わせること) <br> pdo_pgsql / pdo_mysql / pdo_sqlite (利用するデータベースに合わせること) <br> pdo <br> phar <br> mbstring <br> zlib <br> ctype <br> session <br> JSON <br> xml <br> libxml <br> OpenSSL <br> zip <br> cURL <br> fileinfo <br> intl <br> GD <br> Sodium(※4) |
 |推奨ライブラリ|hash <br> APCu / WinCache (利用する環境に合わせること) <br> Zend OPcache |
 
-※4 EC-CUBE 4.2系は Sodium拡張 が必要になります。
+※4 EC-CUBE 4.2系は Web API プラグインを利用する場合、Sodium拡張 が必要になります。
 
 # 動作確認ブラウザ
 


### PR DESCRIPTION
EC-CUBE4.2系の必須PHPライブラリ：sodium 拡張の追加