### PR TITLE
jekyllのイメージをバージョン固定

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   jekyll:
-    image: bretfisher/jekyll-serve
+    image: bretfisher/jekyll-serve:stable-20220916052939
     command: [ "bundle", "exec", "jekyll", "serve", "--incremental", "--force_polling", "-H", "0.0.0.0", "-P", "4000" ]
     volumes:
       - .:/site:cached


### PR DESCRIPTION
以下のエラー回避のため
```
doc4ec-cubenet-jekyll-1  |       Generating... 
doc4ec-cubenet-jekyll-1  |       Remote Theme: Using theme mmistakes/minimal-mistakes
doc4ec-cubenet-jekyll-1  |        Jekyll Feed: Generating feed for posts
doc4ec-cubenet-jekyll-1  |    GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
doc4ec-cubenet-jekyll-1  |                     done in 14.916 seconds.
doc4ec-cubenet-jekyll-1  |  Auto-regeneration: enabled for '/site'
doc4ec-cubenet-jekyll-1  | bundler: failed to load command: jekyll (/usr/local/bundle/bin/jekyll)
doc4ec-cubenet-jekyll-1  | /usr/local/bundle/gems/jekyll-3.9.3/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
```