### PR TITLE
個人情報取り扱いについてpdfへのリンク修正

### DIFF
--- a/_pages/co/co_security.md
+++ b/_pages/co/co_security.md
@@ -45,7 +45,7 @@ WAFによりWebアプリケーションへの攻撃を検知し、攻撃者か�
 ## 開発としての対策
 
 ### 個人情報の取り扱い
-[個人情報方針](https://www.ec-cube.co/pdf/privacy_policy.pdf){:target="_blank"}、並びに[個人情報の取扱いについて](https://www.ec-cube.net/policy/){:target="_blank"} を参照してください。
+[個人情報保護方針](https://www.ec-cube.net/policy/privacy.php){:target="_blank"}、並びに[個人情報の取扱いについて](https://www.ec-cube.net/policy/){:target="_blank"} を参照してください。
 
 ### 開発・運用端末
 

--- a/_pages/co/co_security.md
+++ b/_pages/co/co_security.md
@@ -45,8 +45,7 @@ WAFによりWebアプリケーションへの攻撃を検知し、攻撃者か�
 ## 開発としての対策
 
 ### 個人情報の取り扱い
-
-[個人情報の取扱いについて](https://www.ec-cube.co/pdf/privacy_policy.pdf){:target="_blank"} を参照してください。
+[個人情報方針](https://www.ec-cube.co/pdf/privacy_policy.pdf){:target="_blank"}、並びに[個人情報の取扱いについて](https://www.ec-cube.net/policy/){:target="_blank"} を参照してください。
 
 ### 開発・運用端末
 


### PR DESCRIPTION
## 概要
個人情報取り扱いについてpdfへのリンク修正

## 対象URL
/co/co_security

## 変更内容
※大まかな流れの変更はありません。
■修正前
個人情報の取扱いについて を参照してください。
リンク先：https://www.ec-cube.co/pdf/privacy_policy.pdf

■修正後
個人情報保護方針、並びに個人情報の取扱いについて を参照してください
リンク先(個人情報保護方針)：https://www.ec-cube.net/policy/privacy.php
リンク先(個人情報の取扱いについて)：https://www.ec-cube.net/policy/

## 備考
![after](https://github.com/EC-CUBE/doc4.ec-cube.net/assets/132241702/cd4bec90-746c-4752-b158-4c9c5974f243)

