### PR TITLE
プラグイン導入時以外のトラブル対処方法も記載されているので、タイトルを汎用的なものに変更

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -199,7 +199,7 @@ docs:
       - title: プラグインのインストール
         url: /plugin_install
         output: web, pdf
-      - title: プラグイン導入時のトラブル対処法
+      - title: プラグインのトラブル対処法
         url: /plugin_error
         output: web, pdf
       - title: プラグインサンプル

--- a/_pages/plugin/error.md
+++ b/_pages/plugin/error.md
@@ -1,5 +1,5 @@
 ---
-title: プラグイン導入時のトラブル対処法
+title: プラグインのトラブル対処法
 keywords: plugin error trouble プラグインエラー プラグイントラブル
 tags: [quickstart, getting_started]
 permalink: plugin_error

--- a/index.md
+++ b/index.md
@@ -136,7 +136,7 @@ EC-CUBEの基本情報やご確認いただきたいことについてまとめ�
 
 + [プラグイン仕様](/plugin_spec)
 + [プラグインのインストール](/plugin_install)
-+ [プラグイン導入時のトラブル対処法](/plugin_error)
++ [プラグインのトラブル対処法](/plugin_error)
 + [プラグインサンプル](/plugin_sample)
 + [プラグインを開発する](/plugin_development)
 + [オーナーズストア経由のインストールをテストする](/plugin_mock_package_api)


### PR DESCRIPTION
プラグイン導入時以外のトラブル対処方法も記載されているので、タイトルを汎用的なものに変更しました。
※内容は @yKazihara さんと事前調整済み

### 対象ページ
- https://doc4.ec-cube.net/plugin_error 
- https://doc4.ec-cube.net/ ：目次の中
- 左サイドバー
↓
詳細はコメントご確認ください