### PR TITLE
jekyllのDockerコンテナ立ち上げ失敗に対処

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "webrick"
 gem "minimal-mistakes-jekyll"
 gem "liquid-c"
 


### PR DESCRIPTION
以下の問題対処の根治対応
https://github.com/EC-CUBE/doc4.ec-cube.net/pull/302

Dockerコンテナ立ち上げ時に落ちてしまう原因がwebrickが見つからないことに起因するため、
Gemfileに設定を追加