### PR TITLE
EC-CUBE 4.3リリースによる最新バージョン修正

### DIFF
--- a/_pages/quickstart/latest_version.md
+++ b/_pages/quickstart/latest_version.md
@@ -10,10 +10,10 @@ permalink: quickstart/latest_version
 
 現時点での最新バージョン情報は以下のとおりです。
 
-- [4.2](https://github.com/EC-CUBE/ec-cube/tree/4.2){:target="_blank"}
-- [4.2 リリースノート](https://github.com/EC-CUBE/ec-cube/releases/latest){:target="_blank"}
-- [4.2 ダウンロード](https://www.ec-cube.net/download/){:target="_blank"}
+- [4.3](https://github.com/EC-CUBE/ec-cube/tree/4.3){:target="_blank"}
+- [4.3 リリースノート](https://github.com/EC-CUBE/ec-cube/releases/latest){:target="_blank"}
+- [4.3 ダウンロード](https://www.ec-cube.net/download/){:target="_blank"}
 
 - [システム要件](requirement)
 
-- [4.1から4.2へのマイグレーション](/update-41-42)
+- [4.2から4.3へのマイグレーション](/update-42-43)

--- a/_pages/quickstart/requirement.md
+++ b/_pages/quickstart/requirement.md
@@ -8,6 +8,16 @@ permalink: quickstart/requirement
 
 ---
 
+## 4.3
+
+| 分類 | ソフトウェア|Version|
+|---|-------|---|
+|WebServer|Apache |2.4.x <br> (mod_rewrite / mod_ssl 必須) |
+|PHP |PHP |8.1 〜 8.3 |
+|Database|PostgreSQL|12.x 〜 16.x <br> (pg_settingsテーブルへの参照権限 必須) |
+|Database|MySQL| 8.0<br> (InnoDBエンジン 必須) |
+|Database|SQLite(開発用途向け) |3.x |
+
 ## 4.2
 
 | 分類 | ソフトウェア|Version|


### PR DESCRIPTION
### 概要
EC-CUBE 4.3のリリースに伴い、ドキュメントの最新バージョン情報を修正しました。

### 変更内容
- [最新バージョン](https://doc4.ec-cube.net/quickstart/latest_version)において、リストが4.2となっていたため、4.3に修正
- [システム要件](https://doc4.ec-cube.net/quickstart/requirement)に4.3を追加

### 参考
- [最新バージョン](https://doc4.ec-cube.net/quickstart/latest_version)の修正画面
<img width="300" alt="最新バージョン" src="https://github.com/user-attachments/assets/fb23a2ad-cd87-42ae-9ed0-7a841515dc4c">

- [システム要件](https://doc4.ec-cube.net/quickstart/requirement)の修正画面
<img width="310" alt="システム要件" src="https://github.com/user-attachments/assets/6ab80540-ffa0-4e6b-a9ff-f6caf5fc45e2">