### PR TITLE
多言語化ドキュメントの誤字修正（Resouce→Resource）

### DIFF
--- a/_pages/i18n/multilingualization.md
+++ b/_pages/i18n/multilingualization.md
@@ -46,7 +46,7 @@ ECCUBE_LOCALE=en
 
 ## メッセージファイル(翻訳ファイル)
 
-メッセージファイルは、`src/Eccube/Resouce/locale`以下に保存されています。
+メッセージファイルは、`src/Eccube/Resource/locale`以下に保存されています。
 `ECCUBE_LOCALE`の値に応じて、
 
 - messages.xxx.yaml


### PR DESCRIPTION
## Summary
- ディレクトリ名のスペルミスを修正（Resouce → Resource）

## 変更箇所
`_pages/i18n/multilingualization.md:49`

```diff
- メッセージファイルは、`src/Eccube/Resouce/locale`以下に保存されています。
+ メッセージファイルは、`src/Eccube/Resource/locale`以下に保存されています。
```

## Test plan
- [ ] ドキュメントのビルドが正常に完了すること
- [ ] 該当ページの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)