### PR TITLE
セキュリティガイドラインの表記ゆれを修正

### DIFF
--- a/_pages/security-guideline/coding.md
+++ b/_pages/security-guideline/coding.md
@@ -86,7 +86,7 @@ $resultSet = $stmt->executeQuery();
 return $resultSet->fetchAllAssociative();
 ```
 
-* 推奨された例
+* 推奨例
 
 ```php
 $conn = $this->getEntityManager()->getConnection();
@@ -208,7 +208,7 @@ $dirName = "/path/to/directory/";
 $handle = open($dirName . $fileName, "r");
 ```
 
-* 推奨された例
+* 推奨例
 
 ```php
 $fileName = $request->getParameter('file_path');


### PR DESCRIPTION
## Summary
- 「推奨された例」→「推奨例」に統一

## 変更箇所
`_pages/security-guideline/coding.md:89, 211`

```diff
- * 推奨された例
+ * 推奨例
```

他の箇所では「推奨例」と記載されているため、表記を統一しました。

## Test plan
- [ ] ドキュメントのビルドが正常に完了すること
- [ ] 該当ページの表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)